### PR TITLE
Fix sphinx highlighting

### DIFF
--- a/astroimtools/scripts/imarith.py
+++ b/astroimtools/scripts/imarith.py
@@ -5,6 +5,8 @@
 extracted from two FITS files.  The arithmetic is performed for the data
 in only a single FITS extension in both FITS file.
 
+.. highlight:: none
+
 Example usage:
 
 1.  Add the array in extension 1 of the first FITS file with extension 3
@@ -17,6 +19,8 @@ Example usage:
     "result.fits"::
 
     $ imarith filename1.fits filename2.fits '+' -e1 1 -e2 3 -k 'exptime' -o 'result.fits'
+
+.. highlight:: python3
 """
 
 import argparse

--- a/astroimtools/scripts/imstats.py
+++ b/astroimtools/scripts/imstats.py
@@ -5,6 +5,8 @@
 array from a single extension of a FITS file.  Sigma-clipped statistics
 can be calculated by specifying the ``sigma`` option.
 
+.. highlight:: none
+
 The currently available statistics are:
 
   * ``'mean'``
@@ -55,6 +57,8 @@ Example usage:
        filename    npixels   mean    std     min      max
      ------------- ------- -------- ------ -------- -------
      filename.fits 1020413 0.425871 0.5742 -39.2302 55.2304
+
+.. highlight:: python3
 """
 
 import argparse

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,3 +202,45 @@ github_issues_url = 'https://github.com/{0}/issues/'.format(setup_cfg['github_pr
 #     dtype, target = line.split(None, 1)
 #     target = target.strip()
 #     nitpick_ignore.append((dtype, six.u(target)))
+
+
+# a simple/non-configurable extension that generates the rst files for ipython
+# notebooks
+def notebooks_to_rst(app):
+    from glob import glob
+
+    try:
+        # post "big-split", nbconvert is a separate namespace
+        from nbconvert.nbconvertapp import NbConvertApp
+        from nbconvert.writers import FilesWriter
+    except ImportError:
+        from IPython.nbconvert.nbconvertapp import NbConvertApp
+        from IPython.nbconvert.writers import FilesWriter
+
+    class OrphanizerWriter(FilesWriter):
+        def write(self, output, resources, **kwargs):
+            output = ':orphan:\n\n' + output
+            FilesWriter.write(self, output, resources, **kwargs)
+
+    olddir = os.path.abspath(os.curdir)
+    try:
+        srcdir = os.path.abspath(os.path.split(__file__)[0])
+        os.chdir(os.path.join(srcdir, 'astroimtools', 'notebooks'))
+        nbs = glob('*.ipynb')
+
+        app = NbConvertApp()
+        app.initialize(argv=[])
+        app.writer = OrphanizerWriter()
+
+        app.export_format = 'rst'
+        app.notebooks = nbs
+
+        app.start()
+    except:
+        pass
+    finally:
+        os.chdir(olddir)
+
+
+def setup(app):
+    app.connect('builder-inited', notebooks_to_rst)


### PR DESCRIPTION
The removes the Sphinx warnings:  "WARNING: Could not lex literal_block as "python". Highlighting skipped."

Also, re-adds the sphinx extension to convert notebooks to rst.