### PR TITLE
Update the way the NDDataStats class applies data masking 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,20 +87,15 @@ matrix:
         # astropy >= 3.1 requires numpy >= 1.13
         - stage: Comprehensive tests
           env: PYTHON_VERSION=3.5
-               NUMPY_VERSION=1.11
-               ASTROPY_VERSION=lts
-               PIP_DEPENDENCIES='pytest<3.10'
+               NUMPY_VERSION=1.13
 
         - stage: Comprehensive tests
           env: PYTHON_VERSION=3.6
-               NUMPY_VERSION=1.12 ASTROPY_VERSION=lts
-               PIP_DEPENDENCIES='pytest<3.10'
+               NUMPY_VERSION=1.14
 
         - stage: Comprehensive tests
-          env: PYTHON_VERSION=3.6
-               NUMPY_VERSION=1.13 ASTROPY_VERSION=lts
-               PIP_DEPENDENCIES='pytest<3.10'
-               EVENT_TYPE='pull_request push cron'
+          env: PYTHON_VERSION=3.7
+               NUMPY_VERSION=1.15
 
         # Test with numpy pre-release version
         - stage: Comprehensive tests

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@
 General
 ^^^^^^^
 
+- Astroimtools requires Python version 3.5 or later.
+- Astroimtools requires Numpy version 1.11 or later.
+- Astroimtools requires Astropy version 3.1 or later. [#67]
+
 New Features
 ^^^^^^^^^^^^
 
@@ -16,9 +20,6 @@ API changes
 - ``nddata_stats`` and ``NDDataStats`` sigma-clipping parameters are
   now specified by passing a ``astropy.stats.SigmaClip`` instance to the
   ``sigma_clip`` keyword. [#66]
-
-Bug Fixes
-^^^^^^^^^
 
 Other Changes and Additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/astroimtools/__init__.py
+++ b/astroimtools/__init__.py
@@ -11,7 +11,7 @@ from ._astropy_init import *  # noqa
 import sys
 
 __minimum_python_version__ = '3.5'
-__minimum_numpy_version__ = '1.11'
+__minimum_numpy_version__ = '1.13.0'
 
 
 class UnsupportedPythonError(Exception):

--- a/astroimtools/arithmetic.py
+++ b/astroimtools/arithmetic.py
@@ -103,23 +103,23 @@ def nddata_arith(nddata1, nddata2, operator, fill_value=0., keywords=None):
         raise ValueError('operator "{0}" is not allowed'.format(operator))
 
     if not isinstance(nddata1, NDData) and not isinstance(nddata2, NDData):
-        raise ValueError('nddata1 or nddata2 input must be an '
-                         'astropy.nddata.NDData object.')
+        raise TypeError('nddata1 or nddata2 input must be an '
+                        'astropy.nddata.NDData instance.')
 
     # if nddata1 is a scalar, then make it a NDData object
     if not isinstance(nddata1, NDData):
         nddata1 = np.asanyarray(nddata1)
         if nddata1.size != 1:
-            raise ValueError('nddata1 input must be an astropy.nddata.NDData '
-                             'object or a scalar.')
+            raise TypeError('nddata1 input must be an astropy.nddata.NDData '
+                            'instance or a scalar.')
         nddata1 = NDData(np.zeros_like(nddata2.data) + nddata1)
 
     # if nddata2 is a scalar, then make it a NDData object
     if not isinstance(nddata2, NDData):
         nddata2 = np.asanyarray(nddata2)
         if nddata2.size != 1:
-            raise ValueError('nddata2 input must be an astropy.nddata.NDData '
-                             'object or a scalar.')
+            raise TypeError('nddata2 input must be an astropy.nddata.NDData '
+                            'instance or a scalar.')
         nddata2 = NDData(np.zeros_like(nddata1.data) + nddata2)
 
     if nddata1.data.shape != nddata2.data.shape:

--- a/astroimtools/stats.py
+++ b/astroimtools/stats.py
@@ -5,7 +5,8 @@ Statistics tools.
 
 import numpy as np
 from astropy.nddata import NDData, support_nddata
-from astropy.stats import biweight_location, biweight_midvariance, mad_std
+from astropy.stats import (biweight_location, biweight_midvariance, mad_std,
+                           SigmaClip)
 from astropy.table import Table
 from astropy.utils import lazyproperty
 from astropy.utils.decorators import deprecated_renamed_argument
@@ -147,8 +148,8 @@ class NDDataStats:
                  upper_bound=None, mask_value=None, mask_invalid=True):
 
         if not isinstance(nddata, NDData):
-            raise ValueError('nddata input must be an astropy.nddata.NDData '
-                             'object')
+            raise TypeError('nddata input must be an astropy.nddata.NDData '
+                            'instance')
 
         # update the mask
         mask = mask_databounds(nddata.data, mask=nddata.mask,
@@ -163,6 +164,10 @@ class NDDataStats:
         data = nddata.data[~mask]
 
         if sigma_clip is not None:
+            if not isinstance(sigma_clip, SigmaClip):
+                raise TypeError('sigma_clip must be an '
+                                'astropy.stats.SigmaClip instance')
+
             data = sigma_clip(data, masked=False, axis=None)  # 1D ndarray
 
         self.goodvals = data.ravel()  # 1D array

--- a/astroimtools/stats.py
+++ b/astroimtools/stats.py
@@ -84,68 +84,67 @@ class NDDataStats:
     Class to calculate (sigma-clipped) image statistics on NDData
     objects.
 
-    Set the ``sigma`` keyword to perform sigma clipping.
+    Set the ``sigma_clip`` keyword to perform sigma clipping.
+
+    Parameters
+    ----------
+    nddata : `~astropy.nddata.NDData`
+        NDData object containing the data array (and an optional mask)
+        on which to calculate statistics.  Masked pixels are excluded
+        when computing the image statistics.
+
+    sigma_clip : `astropy.stats.SigmaClip` instance, optional
+        A `~astropy.stats.SigmaClip` object that defines the sigma
+        clipping parameters.  If `None` then no sigma clipping will be
+        performed (default).
+
+    lower_bound : float, optional
+        The minimum data value to include in the statistics.  All pixel
+        values less than ``lower_bound`` will be ignored.  `None` means
+        that no lower bound is applied (default).
+
+    upper_bound : float, optional
+        The maximum data value to include in the statistics.  All pixel
+        values greater than ``upper_bound`` will be ignored.  `None`
+        means that no upper bound is applied (default).
+
+    mask_value : float, optional
+        A data value (e.g., ``0.0``) to be masked.  ``mask_value`` will
+        be masked in addition to any input ``mask``.
+
+    mask_invalid : bool, optional
+        If `True` (the default), then any unmasked invalid values (e.g.
+        NaN, inf) will be masked.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from astropy.nddata import NDData
+    >>> from astroimtools import NDDataStats
+    >>> data = np.arange(10)
+    >>> data[0] = 100.
+    >>> nddata = NDData(data)
+    >>> stats = NDDataStats(nddata)
+    >>> stats.mean
+    14.5
+    >>> stats.std  # doctest: +FLOAT_CMP
+    28.605069480775605
+    >>> stats.mad_std  # doctest: +FLOAT_CMP
+    3.706505546264005
+    >>> from astropy.stats import SigmaClip
+    >>> sigclip = SigmaClip(sigma=2.5)
+    >>> stats = NDDataStats(nddata, sigma_clip=sigclip)
+    >>> stats.mean
+    5.0
+    >>> stats.std  # doctest: +FLOAT_CMP
+    2.581988897471611
+    >>> stats.mad_std  # doctest: +FLOAT_CMP
+    2.965204437011204
     """
 
     @deprecated_renamed_argument('sigma', 'sigma_clip', '0.2')
     def __init__(self, nddata, sigma_clip=None, lower_bound=None,
                  upper_bound=None, mask_value=None, mask_invalid=True):
-        """
-        Parameters
-        ----------
-        nddata : `~astropy.nddata.NDData`
-            NDData object containing the data array (and an optional
-            mask) on which to calculate statistics.  Masked pixels are
-            excluded when computing the image statistics.
-
-        sigma_clip : `astropy.stats.SigmaClip` instance, optional
-            A `~astropy.stats.SigmaClip` object that defines the sigma
-            clipping parameters.  If `None` then no sigma clipping will
-            be performed (default).
-
-        lower_bound : float, optional
-            The minimum data value to include in the statistics.  All
-            pixel values less than ``lower_bound`` will be ignored.
-            `None` means that no lower bound is applied (default).
-
-        upper_bound : float, optional
-            The maximum data value to include in the statistics.  All
-            pixel values greater than ``upper_bound`` will be ignored.
-            `None` means that no upper bound is applied (default).
-
-        mask_value : float, optional
-            A data value (e.g., ``0.0``) to be masked.  ``mask_value``
-            will be masked in addition to any input ``mask``.
-
-        mask_invalid : bool, optional
-            If `True` (the default), then any unmasked invalid values
-            (e.g.  NaN, inf) will be masked.
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from astropy.nddata import NDData
-        >>> from astroimtools import NDDataStats
-        >>> data = np.arange(10)
-        >>> data[0] = 100.
-        >>> nddata = NDData(data)
-        >>> stats = NDDataStats(nddata)
-        >>> stats.mean
-        14.5
-        >>> stats.std  # doctest: +FLOAT_CMP
-        28.605069480775605
-        >>> stats.mad_std  # doctest: +FLOAT_CMP
-        3.706505546264005
-        >>> from astropy.stats import SigmaClip
-        >>> sigclip = SigmaClip(sigma=2.5)
-        >>> stats = NDDataStats(nddata, sigma_clip=sigclip)
-        >>> stats.mean
-        5.0
-        >>> stats.std  # doctest: +FLOAT_CMP
-        2.581988897471611
-        >>> stats.mad_std  # doctest: +FLOAT_CMP
-        2.965204437011204
-        """
 
         if not isinstance(nddata, NDData):
             raise ValueError('nddata input must be an astropy.nddata.NDData '
@@ -300,7 +299,7 @@ def nddata_stats(nddata, sigma_clip=None, columns=None, lower_bound=None,
     """
     Calculate various statistics on the input data.
 
-    Set the ``sigma`` keyword to perform sigma clipping.
+    Set the ``sigma_clip`` keyword to perform sigma clipping.
 
     Parameters
     ----------

--- a/astroimtools/tests/test_arithmetic.py
+++ b/astroimtools/tests/test_arithmetic.py
@@ -71,13 +71,13 @@ class TestNDDataArith:
         assert_allclose(nd.mask, ref_mask)
 
     def test_invalid_scalar_inputs(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             nddata_arith(4, 4, '+')
 
     def test_invalid_array_inputs(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             nddata_arith(np.arange(3), self.nd1, '+')
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             nddata_arith(self.nd2, np.arange(3), '+')
 
     def test_invalid_nddata_shapes(self):

--- a/astroimtools/tests/test_utils.py
+++ b/astroimtools/tests/test_utils.py
@@ -78,7 +78,7 @@ class TestNDDataCutout2D:
         assert cutout.unit == unit
 
     def test_not_nddata(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             nddata_cutout2d(np.ones((10, 10)), (5, 5), (2, 2))
 
     def test_skycoord_no_wcs(self):

--- a/astroimtools/utils.py
+++ b/astroimtools/utils.py
@@ -314,7 +314,7 @@ def nddata_cutout2d(nddata, position, size, mode='trim', fill_value=np.nan):
     from astropy.nddata.utils import Cutout2D
 
     if not isinstance(nddata, NDData):
-        raise ValueError('nddata input must be an NDData object')
+        raise TypeError('nddata input must be an NDData object')
 
     if isinstance(position, SkyCoord):
         if nddata.wcs is None:

--- a/docs/astroimtools/install.rst
+++ b/docs/astroimtools/install.rst
@@ -11,7 +11,7 @@ Astroimtools has the following strict requirements:
 
 * `Numpy <http://www.numpy.org/>`_ |minimum_numpy_version| or later
 
-* `Astropy`_ 2.0 or later
+* `Astropy`_ 3.1 or later
 
 Astroimtools also depends on `pytest-astropy
 <https://github.com/astropy/pytest-astropy>`_ (0.4 or later) to run

--- a/docs/astroimtools/stats.rst
+++ b/docs/astroimtools/stats.rst
@@ -54,7 +54,7 @@ statistics are:
   * ``'std'``
   * ``'mad_std'``
   * ``'npixels'``
-  * ``'nrejected'`` (number of pixels rejected by sigma clipping)
+  * ``'nrejected'`` (number of pixels rejected by masking or sigma clipping)
   * ``'min'``
   * ``'max'``
   * ``'biweight_location'``

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires = astropy
 version = 0.2.dev
 # Note: these versions also need to be defined in the package __init__.py
 minimum_python_version = 3.5
-minimum_numpy_version = 1.11
+minimum_numpy_version = 1.13
 
 [entry_points]
 imarith = astroimtools.scripts.imarith:main


### PR DESCRIPTION
These changes prevent the code from issuing some runtime warnings due to masked arrays.  The code is also simplified using astropy >= 3.1 `SigmaClip`.