### PR TITLE
Remove unnecessary warning when setting mask_invalid

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.3 (unreleased)
 ----------------
 
-- No changes yet
+- The ``mask_databounds`` function no longer raises a warning if the
+  ``mask_invalid`` keyword is set to ``True``. [#72]
 
 
 0.2 (2019-03-01)
@@ -11,7 +12,9 @@ General
 ^^^^^^^
 
 - Astroimtools requires Python version 3.5 or later.
+
 - Astroimtools requires Numpy version 1.11 or later.
+
 - Astroimtools requires Astropy version 3.1 or later. [#67]
 
 New Features
@@ -39,4 +42,4 @@ Other Changes and Additions
 0.1 (2015-12-17)
 ----------------
 
-Astroimtools requires Astropy version 1.1 or later.
+- Astroimtools requires Astropy version 1.1 or later.

--- a/astroimtools/utils.py
+++ b/astroimtools/utils.py
@@ -2,16 +2,15 @@
 """
 Misc utility functions.
 """
-import numpy as np
 import warnings
 
+import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.nddata import NDData, support_nddata
-from astropy.nddata.utils import overlap_slices
+from astropy.nddata.utils import overlap_slices, Cutout2D
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs.utils import skycoord_to_pixel
-
 
 __all__ = ['radial_distance', 'listpixels', 'mask_databounds',
            'nddata_cutout2d']
@@ -215,12 +214,7 @@ def mask_databounds(data, mask=None, lower_bound=None, upper_bound=None,
         data = np.ma.masked_values(data, value)
 
     if mask_invalid:
-        nmasked = data.count()
         data = np.ma.masked_invalid(data)    # mask np.nan, np.inf
-        if data.count() != nmasked:
-            warnings.warn('The data array contains unmasked invalid '
-                          'values (NaN or inf), which are now masked.',
-                          AstropyUserWarning)
 
     if np.all(data.mask):
         raise ValueError('All data values are masked')
@@ -310,8 +304,6 @@ def nddata_cutout2d(nddata, position, size, mode='trim', fill_value=np.nan):
     >>> cutout.unit
     Unit("electron / s")
     """
-
-    from astropy.nddata.utils import Cutout2D
 
     if not isinstance(nddata, NDData):
         raise TypeError('nddata input must be an NDData object')


### PR DESCRIPTION
The warning is unnecessary because the user explicitly set the `mask_invalid` keyword.