### PR TITLE
Update codecov-action to v2

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -85,6 +85,6 @@ jobs:
       run: tox -e ${{ matrix.tox_env }} -- --remote-data=any
     - name: Upload coverage to codecov
       if: "endsWith(matrix.tox_env, '-cov')"
-      uses: codecov/codecov-action@v1.0.13
+      uses: codecov/codecov-action@v2
       with:
         file: ./coverage.xml


### PR DESCRIPTION
codecov-action v1 uses the codecov bash uploader, which is now deprecated.

xref: https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1
xref: https://about.codecov.io/blog/introducing-codecovs-new-uploader/