### PR TITLE
Drop python 3.6 and 3.7

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -20,42 +20,42 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.6'
-            tox_env: 'py36-test-alldeps'
-          - os: ubuntu-latest
-            python: '3.7'
-            tox_env: 'py37-test-alldeps'
-          - os: ubuntu-latest
-            python: '3.8'
-            tox_env: 'py38-test-alldeps-cov'
-            use_remote_data: true
-          - os: macos-latest
             python: '3.8'
             tox_env: 'py38-test-alldeps'
           - os: ubuntu-latest
-            python: '3.8'
-            tox_env: 'py38-test'
+            python: '3.9'
+            tox_env: 'py39-test-alldeps-cov'
+            use_remote_data: true
+          - os: macos-latest
+            python: '3.9'
+            tox_env: 'py39-test-alldeps'
+          - os: windows-latest
+            python: '3.9'
+            tox_env: 'py39-test-alldeps'
           - os: ubuntu-latest
-            python: '3.8'
+            python: '3.9'
+            tox_env: 'py39-test'
+          - os: ubuntu-latest
+            python: '3.9'
             tox_env: 'codestyle'
           - os: ubuntu-latest
-            python: '3.8'
+            python: '3.9'
             tox_env: 'build_docs'
           - os: ubuntu-latest
-            python: '3.8'
+            python: '3.9'
             tox_env: 'linkcheck'
           - os: ubuntu-latest
-            python: '3.8'
+            python: '3.9'
             tox_env: 'bandit'
           - os: ubuntu-latest
-            python: '3.6'
-            tox_env: 'py36-test-alldeps-astropylts-numpy117'
-          - os: ubuntu-latest
-            python: '3.7'
-            tox_env: 'py37-test-alldeps-astropylts-numpy118'
+            python: '3.8'
+            tox_env: 'py38-test-alldeps-astropylts-numpy118'
           - os: ubuntu-latest
             python: '3.8'
-            tox_env: 'py38-test-alldeps-devdeps'
+            tox_env: 'py38-test-alldeps-astropylts-numpy118'
+          - os: ubuntu-latest
+            python: '3.9'
+            tox_env: 'py39-test-alldeps-devdeps'
 
     steps:
     - name: Check out repository

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   image: latest
 
 python:
-  version: 3.7
+  version: 3.9
   install:
     - method: pip
       path: .

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,13 +7,13 @@ Requirements
 
 Astroimtools has the following strict requirements:
 
-* `Python <https://www.python.org/>`_ 3.6 or later
+* `Python <https://www.python.org/>`_ 3.8 or later
 
-* `Numpy <https://numpy.org/>`_ 1.16 or later
+* `Numpy <https://numpy.org/>`_ 1.18 or later
 
-* `Astropy`_ 3.2 or later
+* `Astropy`_ 5.0 or later
 
-* `Scipy <https://www.scipy.org/>`_ 1.1 or later
+* `Scipy <https://www.scipy.org/>`_ 1.6.0 or later
 
 `pytest-astropy <https://github.com/astropy/pytest-astropy>`_ is
 required to run the test suite.
@@ -21,10 +21,10 @@ required to run the test suite.
 Some functionality is available only if the following optional
 dependencies are installed:
 
-* `Photutils <https://photutils.readthedocs.io/en/latest/>`_ 0.7.2 or
+* `Photutils <https://photutils.readthedocs.io/en/latest/>`_ 1.0.0 or
   later:  Used in cutout tools.
 
-* `Matplotlib <https://matplotlib.org/>`_ 2.2 or later:  Used in
+* `Matplotlib <https://matplotlib.org/>`_ 3.1 or later:  Used in
   cutout tools.
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,11 +23,12 @@ classifiers =
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
-    astropy >= 3.2
-    scipy
+    numpy>=1.18
+    astropy>=5.0
+    scipy>=1.6.0
 
 [options.entry_points]
 console_scripts =
@@ -41,11 +42,11 @@ docs =
     sphinx-astropy
     ipython
     nbsphinx
-    matplotlib
-    photutils
+    matplotlib>=3.1
+    photutils>=1.0.0
 all =
-    matplotlib
-    photutils
+    matplotlib>=3.1
+    photutils>=1.0.0
 
 [options.package_data]
 astroimtools = data/*

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{36,37,38}-test{,-alldeps,-devdeps}{,-cov}
-    py{36,37,38}-test-numpy{116,117,118,119}
-    py{36,37,38}-test-astropy{32,40,lts}
+    py{38,39,310}-test{,-alldeps,-devdeps}{,-cov}
+    py{38,39,310}-test-numpy{118,119,120,121}
+    py{38,39,310}-test-astropy{50,lts}
     build_docs
     linkcheck
     codestyle
@@ -17,15 +17,15 @@ indexserver =
 [testenv]
 # Pass through the following environment variables which may be needed
 # for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
+passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI
 
 # Run the tests in a temporary directory to make sure that we don't
 # import this package from the source tree
 changedir = .tmp/{envname}
 
 # tox environments are constructed with so-called 'factors' (or terms)
-# separated by hyphens, e.g., test-devdeps-cov. Lines below starting with
-# factor: will only take effect if that factor is included in the
+# separated by hyphens, e.g., test-devdeps-cov. Lines below starting
+# with factor: will only take effect if that factor is included in the
 # environment name. To see a list of example environments that can be
 # run, along with a description, run:
 #
@@ -37,35 +37,31 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy116: with numpy 1.16.*
-    numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
     numpy119: with numpy 1.19.*
-    astropy32: with astropy 3.2.*
-    astropy40: with astropy 4.0.*
+    numpy120: with numpy 1.20.*
+    numpy121: with numpy 1.21.*
+    astropy50: with astropy 5.0.*
     astropylts: with the latest astropy LTS
 
 # The following provides some specific pinnings for key packages
 deps =
     cov: coverage
 
-    numpy116: numpy==1.16.*
-    numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
     numpy119: numpy==1.19.*
-
-    astropy32: astropy==3.2.*
-    astropy40: astropy==4.0.*
-    astropylts: astropy==4.0.*
+    numpy120: numpy==1.20.*
+    numpy121: numpy==1.21.*
+    astropy50: astropy==5.0.*
+    astropylts: astropy==5.0.*
 
     devdeps: :NIGHTLY:numpy
-    devdeps: git+https://github.com/numpy/numpy.git#egg=numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
 
 # The following indicates which extras_require from setup.cfg will be
 # installed
 extras =
-    test
+    test: test
     alldeps: all
     build_docs: docs
 
@@ -94,7 +90,7 @@ commands =
 [testenv:codestyle]
 skip_install = true
 changedir = .
-description = check code style, e.g., with flake8
+description = check code style with flake8
 deps = flake8
 commands = flake8 astroimtools --count --max-line-length=100
 


### PR DESCRIPTION
This PR updates the Python minversion and min versions of other dependencies (numpy, astropy, matplotlib, etc.) to keep in line with astropy.