### PR TITLE
TST: ci skip is natively supported now

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -15,7 +15,6 @@ jobs:
   ci-tests:
     name: ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
-    if: "!(contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.head_commit.message, '[ci skip]'))"
     strategy:
       matrix:
         include:


### PR DESCRIPTION
For better or worse, but you don't need the `if` anymore. 

Mainly to see if I fixed RTD PR build here.