### PR TITLE
TST: Update URL for Scientific Python nightlies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ requires =
     pip >= 19.3.1
 isolated_build = true
 indexserver =
-    NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    NIGHTLY = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
 [testenv]
 # Pass through the following environment variables which may be needed


### PR DESCRIPTION
Scientific Python packages have moved their nightly wheels to a new location. xref astropy/astropy#14869

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.