### PR TITLE
hdu.writeto() accept overwrite instead of clobber

### DIFF
--- a/astroimtools/cutout_tools.py
+++ b/astroimtools/cutout_tools.py
@@ -176,7 +176,7 @@ def make_cutouts(catalogname, imagename, image_label, apply_rotation=False,
         hdu.header['OBJ_RA'] = (position.ra.deg, 'Cutout object RA in deg')
         hdu.header['OBJ_DEC'] = (position.dec.deg, 'Cutout object DEC in deg')
 
-        hdu.writeto(fname, clobber=clobber)
+        hdu.writeto(fname, overwrite=clobber)
 
         if verbose:
             log.info('Wrote {0}'.format(fname))


### PR DESCRIPTION
The present version of hdu.writeto() accept _overwrite_ as a keyword argument, instead of _clobber_, but they have the same function, which is indicating whether the new file should overwrite the pre-existing file with the same name.