### PR TITLE
Deprecate clobber keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,12 @@ Bug Fixes
 - Fixed ``make_cutouts`` to use the ``overwrite`` keyword instead of the
   removed ``clobber`` keyword when writing FITS files. [#91]
 
+API Changes
+^^^^^^^^^^^
+
+- The ``clobber`` keyword is deprecated in favor of ``overwrite`` in
+  ``make_cutouts`` and ``basic_nddata_to_fits``. [#99]
+
 
 0.3 (2020-08-03)
 ----------------

--- a/astroimtools/cutout_tools.py
+++ b/astroimtools/cutout_tools.py
@@ -13,12 +13,14 @@ from astropy.io import fits
 from astropy.nddata.utils import Cutout2D, NoOverlapError
 from astropy.table import QTable
 from astropy.wcs import WCS, NoConvergence
+from astropy.utils.decorators import deprecated_renamed_argument
 
 __all__ = ['make_cutouts', 'show_cutout_with_slit']
 
 
+@deprecated_renamed_argument('clobber', 'overwrite', '0.4')
 def make_cutouts(catalogname, imagename, image_label, apply_rotation=False,
-                 table_format='ascii.ecsv', image_ext=0, clobber=False,
+                 table_format='ascii.ecsv', image_ext=0, overwrite=False,
                  verbose=True):
     """Make cutouts from a 2D image and write them to FITS files.
 
@@ -73,12 +75,11 @@ def make_cutouts(catalogname, imagename, image_label, apply_rotation=False,
     image_ext : int, optional
         Image extension to extract header and data. Default is 0.
 
-    clobber : bool, optional
+    overwrite : bool, optional
         Overwrite existing files. Default is `False`.
 
     verbose : bool, optional
         Print extra info. Default is `True`.
-
     """
     # Optional dependencies...
     from reproject import reproject_interp
@@ -170,7 +171,7 @@ def make_cutouts(catalogname, imagename, image_label, apply_rotation=False,
         hdu.header['OBJ_RA'] = (position.ra.deg, 'Cutout object RA in deg')
         hdu.header['OBJ_DEC'] = (position.dec.deg, 'Cutout object DEC in deg')
 
-        hdu.writeto(fname, overwrite=clobber)
+        hdu.writeto(fname, overwrite=overwrite)
 
         if verbose:
             log.info(f'Wrote {fname}')

--- a/astroimtools/nddata_adapters.py
+++ b/astroimtools/nddata_adapters.py
@@ -6,6 +6,7 @@ NDData tools for interfacing with FITS files.
 import astropy.io.fits as fits
 from astropy import log
 from astropy.nddata import NDData
+from astropy.utils.decorators import deprecated_renamed_argument
 
 __all__ = ['basic_fits_to_nddata', 'basic_nddata_to_fits']
 
@@ -45,7 +46,8 @@ def basic_fits_to_nddata(filename, exten=0):
     return NDData(data, meta=header)
 
 
-def basic_nddata_to_fits(nddata, filename, clobber=False):
+@deprecated_renamed_argument('clobber', 'overwrite', '0.4')
+def basic_nddata_to_fits(nddata, filename, overwrite=False):
     """
     Write a `~astropy.nddata.NDData` object to a FITS file.
 
@@ -65,7 +67,7 @@ def basic_nddata_to_fits(nddata, filename, clobber=False):
     filename : str
         The path of the output FITS file.
 
-    clobber : bool, optional
+    overwrite : bool, optional
         Set to `True` to overwrite ``filename`` if it already exists.
         The default is `False`.
     """
@@ -88,7 +90,7 @@ def basic_nddata_to_fits(nddata, filename, clobber=False):
         hdus[-1].header['EXTNAME'] = 'MASK'
 
     hdulist = fits.HDUList(hdus)
-    hdulist.writeto(filename, clobber=clobber)
+    hdulist.writeto(filename, overwrite=overwrite)
     log.info(f'Wrote {filename}')
 
     return

--- a/astroimtools/scripts/imarith.py
+++ b/astroimtools/scripts/imarith.py
@@ -49,8 +49,8 @@ def main(args=None):
                         default=None, help='')
     parser.add_argument('-o', '--outfilename', metavar='outfilename',
                         type=str, default='imarith.fits', help='')
-    parser.add_argument('-c', '--clobber', default=False,
-                        action='store_true', help='')
+    parser.add_argument('--overwrite', default=False, action='store_true',
+                        help='Overwrite existing file')
 
     args = parser.parse_args(args)
 
@@ -76,4 +76,4 @@ def main(args=None):
     nddata = nddata_arith(nddata1, nddata2, args.operator,
                           fill_value=args.fill_value, keywords=keywords)
 
-    basic_nddata_to_fits(nddata, args.outfilename, clobber=args.clobber)
+    basic_nddata_to_fits(nddata, args.outfilename, overwrite=args.overwrite)

--- a/docs/notebooks/make_cutouts.ipynb
+++ b/docs/notebooks/make_cutouts.ipynb
@@ -101,7 +101,7 @@
     }
    ],
    "source": [
-    "make_cutouts(catalogname, imagename, 'jwst_nircam_f115w', clobber=True)"
+    "make_cutouts(catalogname, imagename, 'jwst_nircam_f115w', overwrite=True)"
    ]
   },
   {
@@ -119,8 +119,8 @@
    },
    "outputs": [],
    "source": [
-    "make_cutouts(catalogname, imagename, 'jwst_nircam_f200w', clobber=True, verbose=False)\n",
-    "make_cutouts(catalogname, imagename, 'hst_wfc3ir_f160w', clobber=True, verbose=False)"
+    "make_cutouts(catalogname, imagename, 'jwst_nircam_f200w', overwrite=True, verbose=False)\n",
+    "make_cutouts(catalogname, imagename, 'hst_wfc3ir_f160w', overwrite=True, verbose=False)"
    ]
   },
   {
@@ -158,7 +158,7 @@
     }
    ],
    "source": [
-    "make_cutouts(catalogname, imagename, 'jwst_nircam_f115w_rotated', apply_rotation=True, clobber=True)"
+    "make_cutouts(catalogname, imagename, 'jwst_nircam_f115w_rotated', apply_rotation=True, overwrite=True)"
    ]
   },
   {
@@ -536,11 +536,11 @@
     "\n",
     "# Make cutouts for all three instrument/filter combos.\n",
     "make_cutouts(catalogname, path + 'hlsp_candels_hst_acs_gsd01_f814w_v0.5_drz.fits',\n",
-    "             'hst_acs_f814w', clobber=True)\n",
+    "             'hst_acs_f814w', overwrite=True)\n",
     "make_cutouts(catalogname, path + 'hlsp_candels_hst_wfc3_gsd01_f125w_v0.5_drz.fits',\n",
-    "             'hst_wfc3ir_f125w', clobber=True)\n",
+    "             'hst_wfc3ir_f125w', overwrite=True)\n",
     "make_cutouts(catalogname, path + 'hlsp_candels_hst_wfc3_gsd01_f160w_v0.5_drz.fits',\n",
-    "             'hst_wfc3ir_f160w', clobber=True)\n",
+    "             'hst_wfc3ir_f160w', overwrite=True)\n",
     "```"
    ]
   },


### PR DESCRIPTION
This PR deprecates the `clobber` keyword in favor of `overwrite`.